### PR TITLE
simplify rebar config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,73 +3,39 @@
  [
   warnings_as_errors,
   debug_info,
-  {platform_define, "^[0-9]+", namespaced_types},
   {parse_transform, lager_transform}
  ]}.
 
 {deps,
  [
+  lager,
   {ranch, [], {git, "git@github.com:heroku/ranch.git", {branch, "sni"}}},
-  {lager, [], {git, "git@github.com:basho/lager.git", {branch, "master"}}},
   {fernet, [], {git, "git@github.com:bigkevmcd/erlfernet.git", {branch, "master"}}},
   {bitcask, [], {git, "git@github.com:basho/bitcask.git", {branch, "develop"}}}
 ]}.
 
-{profiles, [
-            {test, [{deps,
-                     [
-                      {meck, [],
-                       {git, "git@github.com:eproxus/meck.git",
-                        {branch, "master"}}}
-                     ]
-                    },
-                    {erl_opts, [debug_info,
-                                warnings_as_errors,
-                                {parse_transform, lager_transform}]}                   ]
-            }
-           ]
-}.
+{profiles, [{test, [{deps, [meck]}]}]}.
 
-{overrides,
- [
-  {override, bitcask,
-   [
-    {erl_opts,
-     [warnings_as_errors,
-      debug_info,
-      {platform_define, "^[0-9]+", namespaced_types},
-      {parse_transform, lager_transform}
-     ]},
-    {deps, [lager]},
-    {plugins,
-     [
-      {pc, {git, "git@github.com:blt/port_compiler.git", {branch, "master"}}}
-     ]},
-    {provider_hooks,
-     [
-      {post,
-       [
-        {compile, {pc, compile}},
-        {clean, {pc, clean}}
-       ]
-      }]
-    },
-    {profiles,
-     [
-      {test,
-       [{plugins,
-         [
-          {pc, {git, "git@github.com:blt/port_compiler.git", {branch, "master"}}}
-         ]},
-        {provider_hooks,
-         [
-          {post,
-           [
-            {compile, {pc, compile}},
-            {clean, {pc, clean}}
-           ]
-          }]
-        }]
-      }]}
-   ]}
- ]}.
+{overrides, [
+            {override, bitcask,
+             [
+             {erl_opts,
+              [warnings_as_errors,
+               debug_info,
+               {platform_define, "^[0-9]+", namespaced_types},
+               {parse_transform, lager_transform}
+              ]},
+
+             {deps, [lager]},
+             {plugins, [pc]},
+
+             {artifacts, ["priv/bitcask.so"]},
+
+             {provider_hooks, [
+                              {post, [
+                                     {compile, {pc, compile}},
+                                     {clean, {pc, clean}}
+                                     ]
+                              }]}
+             ]}]
+}.


### PR DESCRIPTION
No need for the `platform_define` in the main `erl_opts`.

Switched `lager` to use the hex package. The rest can eventually be moved to hex packages as well.

Switched `meck` to the hex package and removed the duplicate `erl_opts` settings from the `test` profile.

Modified the bitcask override to use `pc` from hex and added the `artfiacts` config option to ensure that `bitcask.so` exists before considering the bitcask app "valid".
