### PR TITLE
Refactor snit_cert_store

### DIFF
--- a/src/snit.erl
+++ b/src/snit.erl
@@ -11,7 +11,8 @@
 %% Should pick a proper proxy default to be usable, but we need to be
 %% able to override if only to support proxy protocol at some point.
 %% We could just package all the required modules for easy use.
--spec start(Name::atom(), Acceptors::pos_integer(), inet:port(), fun(), module(), term()) -> ok.
+-spec start(Name::atom(), Acceptors::pos_integer(), inet:port(), fun(), module(), term()) ->
+                   {ok, undefined | pid()}.
 start(Name, Acceptors, ListenPort, SNIFun, Protocol, ProtoOpts) ->
     start(Name, Acceptors, ListenPort, SNIFun, Protocol, ProtoOpts, ranch_ssl).
 

--- a/src/snit_ets_store.erl
+++ b/src/snit_ets_store.erl
@@ -7,19 +7,22 @@
          add/3, update/3, upsert/3,
          delete/2,
          lookup/2,
-         encrypted/1,
          terminate/1
         ]).
 
 -define(TABLE, ?MODULE).
--record(state, {encrypted = true :: boolean()}).
+-define(STATE, ?MODULE).
+-define(SR, #?STATE).
+-record(?STATE, {}).
+-type snit_ets_store_state() :: ?SR{}.
+-export_type([snit_ets_store_state/0]).
 
 %%% behavior callbacks
 
 init_store(Args) ->
     Encrypted = proplists:get_value(encrypted, Args, true),
     ets:new(?TABLE, [private, set, named_table, {read_concurrency, true}]),
-    {ok, #state{encrypted=Encrypted}}.
+    {ok, ?SR{}, Encrypted}.
 
 add(Domain, Certs, State) ->
     Reply = case ets:insert_new(?TABLE, {Domain, Certs}) of
@@ -55,9 +58,6 @@ lookup(Domain, State) ->
                 {error, not_found}
         end,
     {Reply, State}.
-
-encrypted(State=#state{encrypted=Encrypted}) ->
-    {Encrypted, State}.
 
 terminate(_State) ->
     %% shouldn't need to terminate ets store as it's owned by this process.

--- a/test/mock_pallet.erl
+++ b/test/mock_pallet.erl
@@ -27,13 +27,6 @@ setup() ->
                   Key = fernet:generate_token(Plaintext, ?PLAINTEXT),
                   {ok, Key, ?CIPHERTEXT}
               end),
-%    meck:expect(pallet_kms, decrypt,
-%              fun(_Client, Ciphertext, ?CIPHERTEXT) ->
-%                  fernet:verify_and_decrypt_token(Ciphertext, ?PLAINTEXT,
-%                                                  infinity)
-%              end),
-%    meck:expect(pallet_kms, encrypt,
-%        fun(_, _) -> {ok, <<>>, <<>>} end),
     ok.
 
 teardown() ->


### PR DESCRIPTION
- Moved encrypted boolean out of callback modules and into `snit_cert_store`
- Fixed existing dialyzer errors
- renamed `#state{}` records to something more verbose for readability is support crash logs
