### PR TITLE
Move up GCM ciphersuites

### DIFF
--- a/src/snit.app.src
+++ b/src/snit.app.src
@@ -45,6 +45,10 @@
     {cipher_suites, [
         {"ECDHE-ECDSA-AES256-GCM-SHA384",
          [{ecdhe_ecdsa,aes_256_gcm,null}, {ecdhe_ecdsa,aes_256_gcm,null,sha384}]},
+        {"ECDHE-ECDSA-AES128-GCM-SHA256",
+         [{ecdhe_ecdsa,aes_128_gcm,null}, {ecdhe_ecdsa,aes_128_gcm,null,sha256}]},
+        {"ECDHE-RSA-AES128-GCM-SHA256",
+         [{ecdhe_rsa,aes_128_gcm,null}, {ecdhe_rsa,aes_128_gcm,null,sha256}]},
         % missing pre-18.3
         % {"ECDHE-RSA-AES256-GCM-SHA384",
         %  [{ecdhe_rsa,aes_256_gcm,null}, {ecdhe_rsa,aes_256_gcm,null,sha384}]}
@@ -56,10 +60,6 @@
          [{ecdhe_rsa,aes_256_cbc,sha}]},
         {"ECDHE-ECDSA-AES256-SHA",
          [{ecdhe_ecdsa,aes_256_cbc,sha}]},
-        {"ECDHE-ECDSA-AES128-GCM-SHA256",
-         [{ecdhe_ecdsa,aes_128_gcm,null}, {ecdhe_ecdsa,aes_128_gcm,null,sha256}]},
-        {"ECDHE-RSA-AES128-GCM-SHA256",
-         [{ecdhe_rsa,aes_128_gcm,null}, {ecdhe_rsa,aes_128_gcm,null,sha256}]},
         {"ECDHE-ECDSA-AES128-SHA256",
          [{ecdhe_ecdsa,aes_128_cbc,sha256}, {ecdhe_ecdsa,aes_128_cbc,sha256,sha256}]},
         {"ECDHE-RSA-AES128-SHA256",


### PR DESCRIPTION
This should avoid the google ban for HTTP2 blacklisted ciphersuites due
to server order, even though the auditor did prefer AES256 over the
rest; OTOH, CBC mode is kind of weak so welp.

Alternative: revert 95c44857bf36be832e1ff42e081b4afa905fe348 and go back
to the AWS list.
