### PR TITLE
Allow overriding of default TLS versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ It provides a set of options that make it safe to set up a public-facing Erlang/
 - Setting up a general security policy (based on Mozilla's and AWS) for cipher suites and their ordering
 - Prioritizing ECCs to be performant and matching other industry players
 - Disabling client-initiated renegotiations, and mandating secure one otherwise
-- Restricting the set of allowed TLS/SSL versions (TLS 1.0 still allowed)
 
 Build
 -----
@@ -109,6 +108,7 @@ On top of a strong rationale, we also expect:
 Changelog
 ---------
 
+- 1.0.2: allowing to specify versions rather than enforce them (i.e. disable tlv1), but switch the previous versions to defaults
 - 1.0.1: adding OTP-21 support
 - 1.0.0: open-source release
 - 0.3.2: ECC curve selection

--- a/src/snit.erl
+++ b/src/snit.erl
@@ -86,7 +86,8 @@ start_opts(Name, Acceptors, Protocol, ProtoOpts, SSLTransport, SSLOpts0) ->
 
     DefaultOpts =
         [
-         {alpn_preferred_protocols, ALPN}
+         {alpn_preferred_protocols, ALPN},
+         {versions, ['tlsv1.2', 'tlsv1.1', 'tlsv1']}
         ],
 
     OverrideOpts =
@@ -98,8 +99,10 @@ start_opts(Name, Acceptors, Protocol, ProtoOpts, SSLTransport, SSLOpts0) ->
          {honor_cipher_order, true},
          {secure_renegotiate, true},
          {client_renegotiation, false},
-         {max_connections, infinity},
-         {versions, ['tlsv1.2', 'tlsv1.1', 'tlsv1']}
+         {max_connections, infinity}
+         %% Don't override versions since someone might want something
+         %% stricter than what is defined here.
+         % {versions, ['tlsv1.2', 'tlsv1.1', 'tlsv1']}
          %% missing: reuse_session, reuse_sessions
         ] ++ ECCs,
 


### PR DESCRIPTION
Prior to this commit, the TLS versions 1.0, 1.1, and 1.2 were mandated
by default, and could not be overriden.

Times change and TLSv1.0 is often a thing you'd want to disable, and
even TLSv1.1. OTP-22 introduces initial (non-production) implementations
of TLSv1.3 as well, which users may want to enable.

This commit fixes this by moving the default versions to just being a
default (so that if they are not specified, you don't accidentally
enable even older TLS versions), but allowing them to be overriden in
snit:start_opts/6. This also allows per-server options to be set there,
creating safer or riskier endpoints on purpose (the same change can't be
done with SNI only).